### PR TITLE
Lookup User Ids

### DIFF
--- a/app/bq_service.py
+++ b/app/bq_service.py
@@ -511,6 +511,7 @@ class BigQueryService():
             sql += f"DROP TABLE IF EXISTS `{self.dataset_address}.user_id_lookups`; "
         sql += f"""
             CREATE TABLE `{self.dataset_address}.user_id_lookups` (
+                counter INTEGER,
                 screen_name STRING,
                 user_id STRING,
                 message STRING

--- a/app/bq_service.py
+++ b/app/bq_service.py
@@ -511,7 +511,8 @@ class BigQueryService():
             sql += f"DROP TABLE IF EXISTS `{self.dataset_address}.user_id_lookups`; "
         sql += f"""
             CREATE TABLE `{self.dataset_address}.user_id_lookups` (
-                counter INTEGER,
+                lookup_at TIMESTAMP,
+                counter INT64,
                 screen_name STRING,
                 user_id STRING,
                 message STRING

--- a/app/bq_service.py
+++ b/app/bq_service.py
@@ -20,7 +20,7 @@ DEFAULT_START = "2019-12-02 01:00:00" # the "beginning of time" for the impeachm
 DEFAULT_END = "2020-03-24 20:00:00" # the "end of time" for the impeachment dataset. todo: allow customization via env var
 
 def generate_timestamp(): # todo: maybe a class method
-    """Formats datetime for storing in BigQuery (consider moving)"""
+    """Formats datetime for storing in BigQuery"""
     return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
 def generate_temp_table_id(): # todo: maybe a class method
@@ -28,7 +28,7 @@ def generate_temp_table_id(): # todo: maybe a class method
 
 class BigQueryService():
 
-    def __init__(self, project_name=PROJECT_NAME, dataset_name=DATASET_NAME, init_tables=False,
+    def __init__(self, project_name=PROJECT_NAME, dataset_name=DATASET_NAME,
                         verbose=VERBOSE_QUERIES, destructive=DESTRUCTIVE_MIGRATIONS):
         self.project_name = project_name
         self.dataset_name = dataset_name
@@ -48,35 +48,9 @@ class BigQueryService():
 
         seek_confirmation()
 
-        # did this originally, but commenting out now to prevent accidental table deletions
-        # if init_tables == True:
-        #     self.init_tables()
-
     @property
     def metadata(self):
         return {"dataset_address": self.dataset_address, "destructive": self.destructive, "verbose": self.verbose}
-
-    #@classmethod
-    #def cautiously_initialized(cls):
-    #    """ DEPRECATE ME """
-    #    service = BigQueryService()
-    #    if APP_ENV == "development":
-    #        print("-------------------------")
-    #        print("BIGQUERY CONFIG...")
-    #        print("  DATASET ADDRESS:", service.dataset_address.upper())
-    #        print("  DESTRUCTIVE MIGRATIONS:", service.destructive)
-    #        print("  VERBOSE QUERIES:", service.verbose)
-    #        print("-------------------------")
-    #        if input("CONTINUE? (Y/N): ").upper() != "Y":
-    #            print("EXITING...")
-    #            exit()
-    #    # service.init_tables() # did this originally, but commenting out now to prevent accidental table deletions
-    #    return service
-
-    #def init_tables(self):
-    #    """ Creates new tables for storing follower graphs """
-    #    self.migrate_populate_users()
-    #    self.migrate_user_friends()
 
     def execute_query(self, sql):
         """Param: sql (str)"""
@@ -535,7 +509,7 @@ class BigQueryService():
 
 if __name__ == "__main__":
 
-    service = BigQueryService.cautiously_initialized()
+    service = BigQueryService()
 
     print("--------------------")
     print("FETCHED TOPICS:")

--- a/app/bq_service.py
+++ b/app/bq_service.py
@@ -316,7 +316,6 @@ class BigQueryService():
 
         return self.execute_query_in_batches(sql)
 
-
     def fetch_specific_user_friends(self, screen_names):
         sql = f"""
             SELECT user_id, screen_name, friend_count, friend_names, start_at, end_at
@@ -372,7 +371,7 @@ class BigQueryService():
         return self.execute_query(sql)
 
     #
-    # LOCAL ANALYSIS
+    # LOCAL ANALYSIS (PG PIPELINE)
     #
 
     def fetch_user_details_in_batches(self, limit=None):
@@ -490,6 +489,18 @@ class BigQueryService():
         """
         return self.execute_query(sql)
 
+    #
+    # RETWEET GRAPHS V2
+    #
+
+    def fetch_idless_screen_names(self):
+        sql = f"""
+            SELECT DISTINCT rt.retweet_user_screen_name as screen_name
+            FROM {self.dataset_address}.retweets rt
+            LEFT JOIN {self.dataset_address}.tweets t on t.user_screen_name = rt.retweet_user_screen_name
+            WHERE t.user_id IS NULL
+        """
+        return self.execute_query(sql)
 
 if __name__ == "__main__":
 

--- a/app/friend_graphs/bq_grapher.py
+++ b/app/friend_graphs/bq_grapher.py
@@ -11,7 +11,7 @@ class BigQueryGrapher(BaseGrapher):
 
     def __init__(self, bq_service=None, gcs_service=None):
         super().__init__(gcs_service=gcs_service)
-        self.bq_service = (bq_service or BigQueryService.cautiously_initialized())
+        self.bq_service = bq_service or BigQueryService()
 
     @property
     def metadata(self):

--- a/app/pg_pipeline/__init__.py
+++ b/app/pg_pipeline/__init__.py
@@ -30,7 +30,7 @@ def clean_string(dirty):
 class Pipeline():
     def __init__(self, users_limit=USERS_LIMIT, batch_size=BATCH_SIZE,
                         pg_destructive=PG_DESTRUCTIVE, bq_service=None):
-        self.bq_service = (bq_service or BigQueryService.cautiously_initialized())
+        self.bq_service = bq_service or BigQueryService()
         if users_limit:
             self.users_limit = int(users_limit)
         else:

--- a/app/retweet_graphs/README.md
+++ b/app/retweet_graphs/README.md
@@ -252,17 +252,3 @@ CREATE TABLE IF NOT EXISTS impeachment_production.retweets as (
   WHERE retweet_status_id is not null
 );
 ```
-
-Begin to reverse-engineer retweeted user ids:
-
-```sql
-drop table if exists impeachment_development.retweeted_users;
-create table impeachment_development.retweeted_users as (
-  select
-      retweet_user_screen_name,
-      count(distinct status_id) as retweeted_count
-  from impeachment_development.retweets
-  group by 1
-  order by 2 desc
-)
-```

--- a/app/retweet_graphs_v2/README.md
+++ b/app/retweet_graphs_v2/README.md
@@ -181,4 +181,22 @@ LEFT JOIN impeachment_production.retweets rt ON upper(rt.retweet_user_screen_nam
 GROUP BY 1,2
 ORDER by 3 desc
 -- 2224 users without ids have been retweeted, some thousands of times. interesting. exporting to sheets.
+
+
+```
+
+
+```sql
+-- it could be that these screen names are old and we have a match?
+
+SELECT
+  i.screen_name
+  ,i.lookup_error
+  ,count(distinct d.user_id) as user_id_count
+FROM impeachment_production.idless_users i
+JOIN impeachment_production.user_details d ON upper(i.screen_name) in UNNEST(d.screen_names)
+GROUP BY 1,2
+ORDER by 3 desc
+
+-- only two users match.
 ```

--- a/app/retweet_graphs_v2/README.md
+++ b/app/retweet_graphs_v2/README.md
@@ -55,4 +55,8 @@ Only fetching ids for 17K users...
 
 ```sh
 python app.retweet_graphs_v2.lookup_user_ids
+
+DESTRUCTIVE_MIGRATIONS="true" BIGQUERY_DATASET_NAME="impeachment_production" python -m app.retweet_graphs_v2
+.lookup_user_ids # will probably hit rate limits, but will auto-sleep and restart when able
+
 ```

--- a/app/retweet_graphs_v2/README.md
+++ b/app/retweet_graphs_v2/README.md
@@ -1,0 +1,58 @@
+# Retweet Graphs v2
+
+## BigQuery Migrations
+
+We need to make graphs using user ids, not screen names. Because screen names can change. So let's construct some tables on BigQuery for user screen name to id conversion.
+
+```sql
+DROP TABLE IF EXISTS impeachment_production.retweets;
+CREATE TABLE IF NOT EXISTS impeachment_production.retweets as (
+  SELECT
+    user_id
+    ,user_created_at
+    ,user_screen_name
+    ,split(SPLIT(status_text, "@")[OFFSET(1)], ":")[OFFSET(0)] as retweet_user_screen_name
+    ,status_id
+    ,status_text
+    ,created_at
+  FROM impeachment_production.tweets
+  WHERE retweet_status_id is not null
+);
+```
+
+```sql
+--DROP TABLE IF EXISTS impeachment_production.user_screen_names;
+--CREATE TABLE impeachment_production.user_screen_names as (
+  SELECT DISTINCT screen_name
+  FROM (
+    SELECT DISTINCT user_screen_name as screen_name FROM impeachment_production.tweets
+    UNION ALL
+    SELECT DISTINCT retweet_user_screen_name as screen_name FROM impeachment_production.retweets
+  ) subq
+  ORDER BY screen_name
+--);
+
+
+-- from tweets, there can be many screen names per user id
+-- first lets get all the unique screen names of those tweeting and being retweeted
+-- we can use the retweets table which has the retweeted user screen name, but we'll have to assign them unique ids or fetch their ids from twitter. will we be able to find them all? next time get them immediately after collecting the tweet.
+-- but the bots are the ones doing the retweeting, so we have their ids, so things should be fine if we assign unique ids for each retweeted user screen name, or use the screen name itself.
+-- so we need a column with screen name as the primary key
+-- and another column of the corresponding user id (as a string is fine)
+```
+
+
+```sql
+SELECT
+  count(distinct sn.screen_name) as sn_count -- 3,653,231
+  ,count(distinct CASE WHEN t.user_id IS NULL THEN sn.screen_name END) as idless_sn_count -- 17,196
+  ,count(distinct t.user_id) as id_count -- 3,600,545
+FROM impeachment_production.user_screen_names sn
+LEFT JOIN impeachment_production.tweets t on t.user_screen_name = sn.screen_name
+```
+
+Only fetching ids for 17K users...
+
+```sh
+python app.retweet_graphs_v2.lookup_user_ids
+```

--- a/app/retweet_graphs_v2/lookup_user_ids.py
+++ b/app/retweet_graphs_v2/lookup_user_ids.py
@@ -1,4 +1,6 @@
 
+import json
+from tweepy.error import TweepError
 
 from app.bq_service import BigQueryService
 from app.twitter_service import TwitterService
@@ -11,8 +13,20 @@ if __name__ == "__main__":
 
     batch = []
     for row in bq_service.fetch_idless_screen_names():
-        user_id = twitter_service.get_user_id(row.screen_name)
-        lookup = {"screen_name": row.screen_name.upper(), "user_id": user_id}
+
+        try:
+            #print(row.screen_name)
+            user_id = twitter_service.get_user_id(row.screen_name)
+            message = None
+        except TweepError as err:
+            #print(err)
+            #> [{'code': 50, 'message': 'User not found.'}]
+            #> [{'code': 63, 'message': 'User has been suspended.'}]
+            #print("USER SUSPENDED!")
+            user_id = None
+            message = json.loads(err.reason.replace("'", '"'))[0]["message"]
+
+        lookup = {"screen_name": row.screen_name.upper(), "user_id": user_id, "message": message}
         print(lookup)
         batch.append(lookup)
 

--- a/app/retweet_graphs_v2/lookup_user_ids.py
+++ b/app/retweet_graphs_v2/lookup_user_ids.py
@@ -1,7 +1,11 @@
 
+import os
 import json
-from tweepy.error import TweepError
 
+from tweepy.error import TweepError
+from pandas import DataFrame
+
+from app import DATA_DIR
 from app.bq_service import BigQueryService
 from app.twitter_service import TwitterService
 
@@ -11,23 +15,28 @@ if __name__ == "__main__":
     bq_service = BigQueryService()
     twitter_service = TwitterService()
 
-    batch = []
+    counter = 1
+    lookups = []
     for row in bq_service.fetch_idless_screen_names():
 
         try:
-            #print(row.screen_name)
             user_id = twitter_service.get_user_id(row.screen_name)
             message = None
         except TweepError as err:
             #print(err)
             #> [{'code': 50, 'message': 'User not found.'}]
             #> [{'code': 63, 'message': 'User has been suspended.'}]
-            #print("USER SUSPENDED!")
             user_id = None
             message = json.loads(err.reason.replace("'", '"'))[0]["message"]
 
-        lookup = {"screen_name": row.screen_name.upper(), "user_id": user_id, "message": message}
+        lookup = {"counter": counter, "screen_name": row.screen_name.upper(), "user_id": user_id, "message": message}
         print(lookup)
-        batch.append(lookup)
+        lookups.append(lookup)
+        counter+=1
 
-    breakpoint()
+    print("-------------")
+    print("LOOKUPS COMPLETE!")
+    df = DataFrame(lookups)
+    print(df.head())
+    csv_filepath = os.path.join(DATA_DIR, "user_id_lookups.csv")
+    df.to_csv(csv_filepath, index=False)

--- a/app/retweet_graphs_v2/lookup_user_ids.py
+++ b/app/retweet_graphs_v2/lookup_user_ids.py
@@ -5,10 +5,9 @@ import json
 from tweepy.error import TweepError
 from pandas import DataFrame
 
-from app import DATA_DIR
+from app import DATA_DIR, seek_confirmation
 from app.bq_service import BigQueryService
 from app.twitter_service import TwitterService
-
 
 if __name__ == "__main__":
 
@@ -36,7 +35,13 @@ if __name__ == "__main__":
 
     print("-------------")
     print("LOOKUPS COMPLETE!")
+
+    print("WRITING TO CSV...")
     df = DataFrame(lookups)
     print(df.head())
     csv_filepath = os.path.join(DATA_DIR, "user_id_lookups.csv")
     df.to_csv(csv_filepath, index=False)
+
+    print("UPLOADING TO BQ...")
+    bq_service.migrate_user_id_lookups()
+    bq_service.upload_user_id_lookups(lookups)

--- a/app/retweet_graphs_v2/lookup_user_ids.py
+++ b/app/retweet_graphs_v2/lookup_user_ids.py
@@ -49,7 +49,7 @@ if __name__ == "__main__":
         batch.append(lookup)
 
         if (len(batch) >= BATCH_SIZE) or (counter >= row_count): # if the batch is full or the row is last
-            print("SAVING BATCH...")
+            print("SAVING BATCH...", len(batch))
             bq_service.upload_user_id_lookups(batch)
             batch = [] # clear the batch
 

--- a/app/retweet_graphs_v2/lookup_user_ids.py
+++ b/app/retweet_graphs_v2/lookup_user_ids.py
@@ -1,0 +1,19 @@
+
+
+from app.bq_service import BigQueryService
+from app.twitter_service import TwitterService
+
+
+if __name__ == "__main__":
+
+    bq_service = BigQueryService()
+    twitter_service = TwitterService()
+
+    batch = []
+    for row in bq_service.fetch_idless_screen_names():
+        user_id = twitter_service.get_user_id(row.screen_name)
+        lookup = {"screen_name": row.screen_name.upper(), "user_id": user_id}
+        print(lookup)
+        batch.append(lookup)
+
+    breakpoint()

--- a/app/retweet_graphs_v2/lookup_user_ids.py
+++ b/app/retweet_graphs_v2/lookup_user_ids.py
@@ -13,21 +13,24 @@ from app.twitter_service import TwitterService
 
 load_dotenv()
 
-BATCH_SIZE = int(os.getenv("BATCH_SIZE", default=1000)) # the max number of processed users to store in BQ at once (with a single insert API call). must be less than 10,000 to avoid error.
+BATCH_SIZE = int(os.getenv("BATCH_SIZE", default=100)) # the max number of processed users to store in BQ at once (with a single insert API call). must be less than 10,000 to avoid error.
 
 if __name__ == "__main__":
-
-    print("BATCH SIZE:", BATCH_SIZE)
 
     bq_service = BigQueryService()
     twitter_service = TwitterService()
 
+    rows = list(bq_service.fetch_idless_screen_names())
+    row_count = len(rows)
+    print("-------------------------")
+    print(f"FETCHED {row_count} SCREEN NAMES")
+    print("BATCH SIZE:", BATCH_SIZE)
+    print("-------------------------")
+
+    seek_confirmation()
     bq_service.migrate_user_id_lookups()
 
     batch = []
-    rows = list(bq_service.fetch_idless_screen_names())
-    row_count = len(rows)
-    print(f"FETCHED {row_count} SCREEN NAMES")
     for index, row in enumerate(rows):
         counter = index + 1
 
@@ -45,18 +48,19 @@ if __name__ == "__main__":
         print(lookup)
         batch.append(lookup)
 
-        if (counter % BATCH_SIZE == 0) or (counter >= row_count): # if the batch is full or the row is last
+        if (len(batch) >= BATCH_SIZE) or (counter >= row_count): # if the batch is full or the row is last
             print("SAVING BATCH...")
             bq_service.upload_user_id_lookups(batch)
+            batch = [] # clear the batch
 
     print("-------------")
     print("LOOKUPS COMPLETE!")
 
-    print("WRITING TO CSV...")
-    df = DataFrame(lookups)
-    print(df.head())
-    csv_filepath = os.path.join(DATA_DIR, "user_id_lookups.csv")
-    df.to_csv(csv_filepath, index=False)
+    #print("WRITING TO CSV...")
+    #df = DataFrame(lookups)
+    #print(df.head())
+    #csv_filepath = os.path.join(DATA_DIR, "user_id_lookups.csv")
+    #df.to_csv(csv_filepath, index=False)
 
     # google.api_core.exceptions.BadRequest: 400 POST https://bigquery.googleapis.com/bigquery/v2/projects/tweet-collector-py/datasets/impeachment_production/tables/user_id_lookups/insertAll: too many rows present in the request, limit: 10000 row count: 17196.
     #bq_service.upload_user_id_lookups(lookups[0:9000])

--- a/app/retweet_graphs_v2/lookup_user_ids.py
+++ b/app/retweet_graphs_v2/lookup_user_ids.py
@@ -4,19 +4,32 @@ import json
 
 from tweepy.error import TweepError
 from pandas import DataFrame
+from dotenv import load_dotenv
 
 from app import DATA_DIR, seek_confirmation
+from app.decorators.datetime_decorators import logstamp
 from app.bq_service import BigQueryService
 from app.twitter_service import TwitterService
 
+load_dotenv()
+
+BATCH_SIZE = int(os.getenv("BATCH_SIZE", default=1000)) # the max number of processed users to store in BQ at once (with a single insert API call). must be less than 10,000 to avoid error.
+
 if __name__ == "__main__":
+
+    print("BATCH SIZE:", BATCH_SIZE)
 
     bq_service = BigQueryService()
     twitter_service = TwitterService()
 
-    counter = 1
-    lookups = []
-    for row in bq_service.fetch_idless_screen_names():
+    bq_service.migrate_user_id_lookups()
+
+    batch = []
+    rows = list(bq_service.fetch_idless_screen_names())
+    row_count = len(rows)
+    print(f"FETCHED {row_count} SCREEN NAMES")
+    for index, row in enumerate(rows):
+        counter = index + 1
 
         try:
             user_id = twitter_service.get_user_id(row.screen_name)
@@ -28,10 +41,13 @@ if __name__ == "__main__":
             user_id = None
             message = json.loads(err.reason.replace("'", '"'))[0]["message"]
 
-        lookup = {"counter": counter, "screen_name": row.screen_name.upper(), "user_id": user_id, "message": message}
+        lookup = {"lookup_at": logstamp(), "counter": counter, "screen_name": row.screen_name.upper(), "user_id": user_id, "message": message}
         print(lookup)
-        lookups.append(lookup)
-        counter+=1
+        batch.append(lookup)
+
+        if (counter % BATCH_SIZE == 0) or (counter >= row_count): # if the batch is full or the row is last
+            print("SAVING BATCH...")
+            bq_service.upload_user_id_lookups(batch)
 
     print("-------------")
     print("LOOKUPS COMPLETE!")
@@ -42,6 +58,7 @@ if __name__ == "__main__":
     csv_filepath = os.path.join(DATA_DIR, "user_id_lookups.csv")
     df.to_csv(csv_filepath, index=False)
 
-    print("UPLOADING TO BQ...")
-    bq_service.migrate_user_id_lookups()
-    bq_service.upload_user_id_lookups(lookups)
+    # google.api_core.exceptions.BadRequest: 400 POST https://bigquery.googleapis.com/bigquery/v2/projects/tweet-collector-py/datasets/impeachment_production/tables/user_id_lookups/insertAll: too many rows present in the request, limit: 10000 row count: 17196.
+    #bq_service.upload_user_id_lookups(lookups[0:9000])
+    #bq_service.upload_user_id_lookups(lookups[9000:18000])
+    # moving forward need to insert in batches less than 10000

--- a/app/twitter_service.py
+++ b/app/twitter_service.py
@@ -1,0 +1,95 @@
+
+
+
+
+
+
+
+
+import os
+from pprint import pprint
+
+from dotenv import load_dotenv
+import tweepy
+
+from app import seek_confirmation
+
+load_dotenv()
+
+CONSUMER_KEY = os.getenv("TWITTER_CONSUMER_KEY", default="OOPS")
+CONSUMER_SECRET = os.getenv("TWITTER_CONSUMER_SECRET", default="OOPS")
+ACCESS_KEY = os.getenv("TWITTER_ACCESS_TOKEN", default="OOPS")
+ACCESS_SECRET = os.getenv("TWITTER_ACCESS_TOKEN_SECRET", default="OOPS")
+
+SCREEN_NAME = os.getenv("TWITTER_SCREEN_NAME", default="elonmusk") # just one to use for testing purposes
+
+class TwitterService:
+    def __init__(self, consumer_key=CONSUMER_KEY, consumer_secret=CONSUMER_SECRET, access_key=ACCESS_KEY, access_secret=ACCESS_SECRET):
+        """
+        See:
+            https://developer.twitter.com/en/docs/basics/rate-limiting
+            http://docs.tweepy.org/en/v3.8.0/auth_tutorial.html
+            https://bhaskarvk.github.io/2015/01/how-to-use-twitters-search-rest-api-most-effectively./
+
+        """
+        auth = tweepy.OAuthHandler(CONSUMER_KEY, CONSUMER_SECRET)
+        auth.set_access_token(ACCESS_KEY, ACCESS_SECRET)
+        self.api = tweepy.API(auth, wait_on_rate_limit=True, wait_on_rate_limit_notify=True)
+
+    def get_user_id(self, screen_name):
+        user = self.api.get_user(SCREEN_NAME)
+        return user.id
+
+    def get_friends(self, screen_name=None, user_id=None, max_friends=2000):
+        """
+        Params:
+            screen_name like "barackobama" or "s2t2" or
+            max_friends for now, for performacne, because we can always go back later and re-scrape those who hit this max
+
+        Returns a list of the user's friend_ids (or empty list if the account was private)
+
+        See: http://docs.tweepy.org/en/v3.8.0/api.html#API.friends_ids
+            https://github.com/tweepy/tweepy/blob/3733fd673b04b9aa193886d6b8eb9fdaf1718341/tweepy/api.py#L542-L551
+            http://docs.tweepy.org/en/v3.8.0/cursor_tutorial.html
+            https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friends-ids
+            https://developer.twitter.com/en/docs/basics/cursoring
+        """
+        if screen_name is not None:
+            cursor = tweepy.Cursor(self.api.friends_ids, screen_name=screen_name, cursor=-1)
+        elif user_id is not None:
+            cursor = tweepy.Cursor(self.api.friends_ids, user_id=user_id, cursor=-1)
+        else:
+            print("OOPS PLEASE PASS SCREEN NAME OR USER ID")
+            return None
+        #print(cursor)
+
+        friend_ids = []
+        try:
+            for friend_id in cursor.items(max_friends):
+                friend_ids.append(friend_id)
+        except tweepy.error.TweepError as err:
+            print("OOPS", err) #> "Not authorized." if user is private / protected (e.g. 1003322728890462209)
+        return friend_ids
+
+if __name__ == "__main__":
+
+    service = TwitterService()
+
+    print("-------------")
+    print(SCREEN_NAME)
+    print("USER ID:")
+    user_id = service.get_user_id(SCREEN_NAME)
+    print(user_id)
+
+    print("-------------")
+    print(SCREEN_NAME)
+    print("FRIEND NAMES:")
+
+    #friend_ids = service.api.friends_ids(SCREEN_NAME)
+    #print(len(friend_ids))
+
+    friend_ids = service.get_friends(screen_name=SCREEN_NAME)
+    print(len(friend_ids))
+
+    friend_ids = service.get_friends(user_id=44196397)
+    print(len(friend_ids))

--- a/app/twitter_service.py
+++ b/app/twitter_service.py
@@ -37,7 +37,7 @@ class TwitterService:
         self.api = tweepy.API(auth, wait_on_rate_limit=True, wait_on_rate_limit_notify=True)
 
     def get_user_id(self, screen_name):
-        user = self.api.get_user(SCREEN_NAME)
+        user = self.api.get_user(screen_name)
         return user.id
 
     def get_friends(self, screen_name=None, user_id=None, max_friends=2000):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 python-dotenv # a.k.a. dotenv, for reading environment vars from the ".env" file
 
+tweepy
 #twint # for unoficially interfacing with twitter data
 beautifulsoup4 # for scraping mobile Twitter site
 


### PR DESCRIPTION
Because user screen names can change over time, it would be more accurate to construct retweet graphs using user ids than screen names. However the way the tweets were collected, if it is a retweet, we have access to the retweeted user's screen name but not their id. So this PR introduces a script to lookup those user ids. 

FYI: Some user ids are not found due to account termination or suspension.