### PR TITLE
Fix uploading of bot classifications to BigQuery

### DIFF
--- a/app/bq_service.py
+++ b/app/bq_service.py
@@ -19,12 +19,17 @@ VERBOSE_QUERIES = (os.getenv("VERBOSE_QUERIES", default="false") == "true")
 DEFAULT_START = "2019-12-02 01:00:00" # the "beginning of time" for the impeachment dataset. todo: allow customization via env var
 DEFAULT_END = "2020-03-24 20:00:00" # the "end of time" for the impeachment dataset. todo: allow customization via env var
 
-def generate_timestamp(): # todo: maybe a class method
+def generate_timestamp():
     """Formats datetime for storing in BigQuery"""
     return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
-def generate_temp_table_id(): # todo: maybe a class method
+def generate_temp_table_id():
     return datetime.now().strftime('%Y_%m_%d_%H_%M_%S')
+
+def split_into_batches(my_list, batch_size=9000):
+    """Splits a list into evenly sized batches""" # h/t: h/t: https://stackoverflow.com/questions/312443/how-do-you-split-a-list-into-evenly-sized-chunks
+    for i in range(0, len(my_list), batch_size):
+        yield my_list[i : i + batch_size]
 
 class BigQueryService():
 
@@ -756,7 +761,14 @@ class BigQueryService():
         Param: records (list of dictionaries)
         """
         rows_to_insert = [list(d.values()) for d in records]
-        errors = self.client.insert_rows(self.daily_bot_probabilities_table, rows_to_insert)
+        #errors = self.client.insert_rows(self.daily_bot_probabilities_table, rows_to_insert)
+        #> google.api_core.exceptions.BadRequest: 400 POST https://bigquery.googleapis.com/bigquery/v2/projects/.../tables/daily_bot_probabilities/insertAll:
+        #> ... too many rows present in the request, limit: 10000 row count: 36092.
+        # see also: https://cloud.google.com/bigquery/quotas#streaming_inserts
+        errors = []
+        batches = list(split_into_batches(rows_to_insert, batch_size=5000))
+        for batch in batches:
+            errors += self.client.insert_rows(self.daily_bot_probabilities_table, batch)
         return errors
 
     def sql_fetch_bot_ids(self, bot_min=0.8):

--- a/app/bq_service.py
+++ b/app/bq_service.py
@@ -762,9 +762,10 @@ class BigQueryService():
         """
         rows_to_insert = [list(d.values()) for d in records]
         #errors = self.client.insert_rows(self.daily_bot_probabilities_table, rows_to_insert)
-        #> google.api_core.exceptions.BadRequest: 400 POST https://bigquery.googleapis.com/bigquery/v2/projects/.../tables/daily_bot_probabilities/insertAll:
+        #> ... google.api_core.exceptions.BadRequest: 400 POST https://bigquery.googleapis.com/bigquery/v2/projects/.../tables/daily_bot_probabilities/insertAll:
         #> ... too many rows present in the request, limit: 10000 row count: 36092.
-        # see also: https://cloud.google.com/bigquery/quotas#streaming_inserts
+        #> ... see: https://cloud.google.com/bigquery/quotas#streaming_inserts
+
         errors = []
         batches = list(split_into_batches(rows_to_insert, batch_size=5000))
         for batch in batches:

--- a/app/gcs_service.py
+++ b/app/gcs_service.py
@@ -60,6 +60,10 @@ class GoogleCloudStorageService:
         blob.download_to_filename(local_filepath)
         return blob
 
+    def file_exists(self, remote_filepath):
+        print("FILE EXISTS?", remote_filepath)
+        blob = self.bucket.blob(remote_filepath)
+        return blob.exists()
 
 if __name__ == "__main__":
 

--- a/app/retweet_graphs_v2/README.md
+++ b/app/retweet_graphs_v2/README.md
@@ -124,7 +124,11 @@ Assigning bot scores for all users in each daily retweet graph, and upload CSV t
 
 ```sh
 APP_ENV="prodlike" K_DAYS=1 START_DATE="2019-12-12" N_PERIODS=60 python -m app.retweet_graphs_v2.k_days.classifier
+
+# SKIP_EXISTING="false" APP_ENV="prodlike" K_DAYS=1 START_DATE="2019-12-19" N_PERIODS=1 python -m app.retweet_graphs_v2.k_days.classifier
 ```
+
+
 
 Downloading bot classifications:
 

--- a/app/retweet_graphs_v2/README.md
+++ b/app/retweet_graphs_v2/README.md
@@ -74,7 +74,10 @@ Empty table which will store bot classifications:
 # python -m app.retweet_graphs_v2.prep.migrate_daily_bot_probabilities
 
 DESTRUCTIVE_MIGRATIONS="true" BIGQUERY_DATASET_NAME="impeachment_production" python -m app.retweet_graphs_v2.prep.migrate_daily_bot_probabilities
+
+DESTRUCTIVE_MIGRATIONS="true" BIGQUERY_DATASET_NAME="impeachment_test" python -m app.retweet_graphs_v2.prep.migrate_daily_bot_probabilities
 ```
+
 
 
 ## Retweet Graphs

--- a/app/retweet_graphs_v2/k_days/classifier.py
+++ b/app/retweet_graphs_v2/k_days/classifier.py
@@ -8,10 +8,6 @@ from app.retweet_graphs_v2.k_days.generator import DateRangeGenerator
 from app.botcode_v2.classifier import NetworkClassifier as BotClassifier
 from app.bq_service import BigQueryService
 
-#def split_into_batches(my_list, batch_size=9000):
-#    """h/t: https://stackoverflow.com/questions/312443/how-do-you-split-a-list-into-evenly-sized-chunks"""
-#    for i in range(0, len(my_list), batch_size):
-#        yield my_list[i : i + batch_size]
 
 if __name__ == "__main__":
 
@@ -39,16 +35,15 @@ if __name__ == "__main__":
         storage.upload_bot_probabilities_histogram()
 
         ## UPLOAD SELECTED ROWS TO BIG QUERY
-        #df = clf.bot_probabilities_df
-        #bots_df = df[df["bot_probability"] > 0.5]
-        #records = [{**{"start_date": date_range.start_date}, **record} for record in bots_df.to_dict("records")]
-        #print("UPLOADING", len(records), "BOT SCORES TO BQ...")
-        ##bq_service.upload_daily_bot_probabilities(records)
-        ##> google.api_core.exceptions.BadRequest: 400 POST https://bigquery.googleapis.com/bigquery/v2/projects/.../tables/daily_bot_probabilities/insertAll: too many rows present in the request, limit: 10000 row count: 36092.
-        ##batches = list(split_into_batches(records))
-        ##for batch in batches:
-        ##    bq_service.upload_daily_bot_probabilities(batch)
-        ##    time.sleep(5)
+        try:
+
+
+            df = clf.bot_probabilities_df
+            bots_df = df[df["bot_probability"] > 0.5]
+            records = [{**{"start_date": date_range.start_date}, **record} for record in bots_df.to_dict("records")]
+            print("UPLOADING", len(records), "BOT SCORES TO BQ...")
+            #bq_service.upload_daily_bot_probabilities(records)
+
 
         # CLEAR MEMORY
         del storage

--- a/app/retweet_graphs_v2/k_days/classifier.py
+++ b/app/retweet_graphs_v2/k_days/classifier.py
@@ -34,24 +34,21 @@ if __name__ == "__main__":
         )
         storage.upload_bot_probabilities_histogram()
 
-        ## UPLOAD SELECTED ROWS TO BIG QUERY
         try:
-
-
+            # UPLOAD SELECTED ROWS TO BIG QUERY (IF POSSIBLE, OTHERWISE CAN ADD FROM GCS LATER)
             df = clf.bot_probabilities_df
             bots_df = df[df["bot_probability"] > 0.5]
             records = [{**{"start_date": date_range.start_date}, **record} for record in bots_df.to_dict("records")]
             print("UPLOADING", len(records), "BOT SCORES TO BQ...")
-            #bq_service.upload_daily_bot_probabilities(records)
+            bq_service.upload_daily_bot_probabilities(records)
+            del df
+            del bots_df
+            del records
+        except Exception as err:
+            print("OOPS", err)
 
-
-        # CLEAR MEMORY
         del storage
         del clf
-        #del df
-        #del bots_df
-        #del records
-        #del batches
         print("\n\n\n\n")
 
     print("JOB COMPLETE!")

--- a/app/retweet_graphs_v2/k_days/classifier.py
+++ b/app/retweet_graphs_v2/k_days/classifier.py
@@ -2,12 +2,17 @@
 import os
 #import time
 
+from dotenv import load_dotenv
+
 from app import APP_ENV, server_sleep
 from app.retweet_graphs_v2.graph_storage import GraphStorage
 from app.retweet_graphs_v2.k_days.generator import DateRangeGenerator
 from app.botcode_v2.classifier import NetworkClassifier as BotClassifier
 from app.bq_service import BigQueryService
 
+load_dotenv()
+
+SKIP_EXISTING = (os.getenv("SKIP_EXISTING", default="true") == "true")
 
 if __name__ == "__main__":
 
@@ -18,8 +23,16 @@ if __name__ == "__main__":
     for date_range in gen.date_ranges:
         storage_dirpath = f"retweet_graphs_v2/k_days/{gen.k_days}/{date_range.start_date}"
         storage = GraphStorage(dirpath=storage_dirpath)
-        storage.report() # loads graph and provides size info
 
+        if SKIP_EXISTING and storage.gcs_service.file_exists(storage.gcs_bot_probabilities_histogram_filepath):
+            # would check for CSV file but it seems checking for larger file sometimes leads to
+            # urllib3.exceptions.ProtocolError: ('Connection aborted.', OSError(0, 'Error')),
+            # so check the smaller histogram file instead
+            print("FOUND EXISTING BOT PROBABILITIES. SKIPPING...")
+            continue # skip to next date range
+
+        print("PROCEEDING WITH CLASSIFICAITON...")
+        storage.report() # loads graph and provides size info
         clf = BotClassifier(storage.graph, weight_attr="weight")
 
         # UPLOAD COMPLETE CSV TO GOOGLE CLOUD STORAGE
@@ -34,14 +47,13 @@ if __name__ == "__main__":
         )
         storage.upload_bot_probabilities_histogram()
 
+        # UPLOAD SELECTED ROWS TO BIG QUERY (IF POSSIBLE, OTHERWISE CAN ADD FROM GCS LATER)
         try:
-            # UPLOAD SELECTED ROWS TO BIG QUERY (IF POSSIBLE, OTHERWISE CAN ADD FROM GCS LATER)
-            df = clf.bot_probabilities_df
-            bots_df = df[df["bot_probability"] > 0.5]
+            bots_df = clf.bot_probabilities_df[clf.bot_probabilities_df["bot_probability"] > 0.5]
             records = [{**{"start_date": date_range.start_date}, **record} for record in bots_df.to_dict("records")]
             print("UPLOADING", len(records), "BOT SCORES TO BQ...")
             bq_service.upload_daily_bot_probabilities(records)
-            del df
+
             del bots_df
             del records
         except Exception as err:

--- a/conftest.py
+++ b/conftest.py
@@ -3,6 +3,8 @@ import os
 import pytest
 from networkx import DiGraph
 
+CI_ENV = (os.getenv("CI") == "true")
+
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "test", "data")
 TMP_DATA_DIR = os.path.join(TEST_DATA_DIR, "tmp")
 

--- a/test/test_bq_service.py
+++ b/test/test_bq_service.py
@@ -1,0 +1,26 @@
+
+import pytest
+
+from conftest import CI_ENV
+from app.bq_service import BigQueryService, split_into_batches
+
+
+def test_split_into_batches():
+    batches = split_into_batches([0,1,2,3,4,5,6,7,8,9,10], 3)
+    assert list(batches) == [
+        [0, 1, 2],
+        [3, 4, 5],
+        [6, 7, 8],
+        [9, 10]
+    ]
+
+@pytest.mark.skipif(CI_ENV, reason="avoid issuing HTTP requests on CI")
+def test_upload_in_batches():
+
+    bq_service = BigQueryService(dataset_name="impeachment_test")
+
+    # when inserting more than 10,000 rows,
+    # is able to overcome error "too many rows present in the request, limit: 10000":
+    lots_of_rows = [{"start_date":"2020-01-01", "user_id":i, "bot_probability": .99} for i in range(1, 36000)]
+    errors = bq_service.upload_daily_bot_probabilities(lots_of_rows)
+    assert not any(errors)


### PR DESCRIPTION
Improves operations surrounding bot classification:
  + Uploads bot classifications in batches to overcome max rows error
  + Doesn't try to classify if classifications exist on Google Cloud Storage